### PR TITLE
Release lock on error

### DIFF
--- a/lib/FtpConnection.js
+++ b/lib/FtpConnection.js
@@ -247,13 +247,25 @@ FtpConnection.prototype._onData = function(data) {
         return self.respond('425 Data connection not configured; send PASV or PORT', release);
       }
 
-      self[m](release, commandArg, command);
+      try {
+        self[m](release, commandArg, command);
+      }
+      catch (e) {
+        release();
+        throw e;
+      }
     }
 
     if (self.allowedCommands != null && self.allowedCommands[command] !== true) {
       self.respond('502 ' + command + ' not implemented.', release);
     } else if (DOES_NOT_REQUIRE_AUTH[command]) {
-      self[m](release, commandArg, command);
+      try {
+        self[m](release, commandArg, command);
+      }
+      catch (e) {
+        release();
+        throw e;
+      }
     } else {
       // If 'tlsOnly' option is set, all commands which require user authentication will only
       // be permitted over a secure connection. See RFC4217 regarding error code.

--- a/lib/FtpConnection.js
+++ b/lib/FtpConnection.js
@@ -235,7 +235,7 @@ FtpConnection.prototype._onData = function(data) {
     return;
   }
 
-  lock('command', function(done) {
+  lock.acquire('command', function(done) {
     var m = '_command_' + command;
     if (!self[m]) {
       return self.respond('502 Command not implemented.', done);
@@ -248,8 +248,7 @@ FtpConnection.prototype._onData = function(data) {
 
       try {
         self[m](done, commandArg, command);
-      }
-      catch (e) {
+      } catch (e) {
         done();
         throw e;
       }
@@ -260,8 +259,7 @@ FtpConnection.prototype._onData = function(data) {
     } else if (DOES_NOT_REQUIRE_AUTH[command]) {
       try {
         self[m](done, commandArg, command);
-      }
-      catch (e) {
+      } catch (e) {
         done();
         throw e;
       }

--- a/lib/FtpConnection.js
+++ b/lib/FtpConnection.js
@@ -7,7 +7,7 @@ var path = require('path');
 var fsModule = require('fs');
 var StatMode = require('stat-mode');
 var dateformat = require('dateformat');
-var lock = require('lock').Lock();
+var AsyncLock = require('async-lock');
 
 var glob = require('./glob');
 var starttls = require('./starttls');
@@ -19,6 +19,7 @@ var stripOptions = require('./helpers/stripOptions');
 var leftPad = require('./helpers/leftPad');
 
 var EventEmitter = events.EventEmitter;
+var lock = new AsyncLock();
 
 // Use LOG for brevity.
 var LOG = Constants.LOG_LEVELS;
@@ -234,47 +235,45 @@ FtpConnection.prototype._onData = function(data) {
     return;
   }
 
-  lock('command', function(releaser) {
-    // releaser is a factory function. It creates a callback that will unlock this critical section.
-    var release = releaser();
+  lock('command', function(done) {
     var m = '_command_' + command;
     if (!self[m]) {
-      return self.respond('502 Command not implemented.', release);
+      return self.respond('502 Command not implemented.', done);
     }
 
     function checkData() {
       if (REQUIRES_CONFIGURED_DATA[command] && !self.dataConfigured) {
-        return self.respond('425 Data connection not configured; send PASV or PORT', release);
+        return self.respond('425 Data connection not configured; send PASV or PORT', done);
       }
 
       try {
-        self[m](release, commandArg, command);
+        self[m](done, commandArg, command);
       }
       catch (e) {
-        release();
+        done();
         throw e;
       }
     }
 
     if (self.allowedCommands != null && self.allowedCommands[command] !== true) {
-      self.respond('502 ' + command + ' not implemented.', release);
+      self.respond('502 ' + command + ' not implemented.', done);
     } else if (DOES_NOT_REQUIRE_AUTH[command]) {
       try {
-        self[m](release, commandArg, command);
+        self[m](done, commandArg, command);
       }
       catch (e) {
-        release();
+        done();
         throw e;
       }
     } else {
       // If 'tlsOnly' option is set, all commands which require user authentication will only
       // be permitted over a secure connection. See RFC4217 regarding error code.
       if (!self.secure && self.server.options.tlsOnly) {
-        self.respond('522 Protection level not sufficient; send AUTH TLS', release);
+        self.respond('522 Protection level not sufficient; send AUTH TLS', done);
       } else if (self.username) {
         checkData();
       } else {
-        self.respond('530 Not logged in.', release);
+        self.respond('530 Not logged in.', done);
       }
     }
 
@@ -283,24 +282,24 @@ FtpConnection.prototype._onData = function(data) {
 };
 
 // Specify the user's account (superfluous)
-FtpConnection.prototype._command_ACCT = function(release) {
-  this.respond('202 Command not implemented, superfluous at this site.', release);
+FtpConnection.prototype._command_ACCT = function(done) {
+  this.respond('202 Command not implemented, superfluous at this site.', done);
 };
 
 // Allocate storage space (superfluous)
-FtpConnection.prototype._command_ALLO = function(release) {
-  this.respond('202 Command not implemented, superfluous at this site.', release);
+FtpConnection.prototype._command_ALLO = function(done) {
+  this.respond('202 Command not implemented, superfluous at this site.', done);
 };
 
-FtpConnection.prototype._command_AUTH = function(release, commandArg) {
+FtpConnection.prototype._command_AUTH = function(done, commandArg) {
   var self = this;
 
   if (!self.server.options.tlsOptions || commandArg !== 'TLS') {
-    return self.respond('502 Command not implemented', release);
+    return self.respond('502 Command not implemented', done);
   }
 
   self.respond('234 Honored', function() {
-    release();
+    done();
     self._logIf(LOG.INFO, 'Establishing secure connection...');
 
     if (!self.socket.authorized && !self.server.options.allowUnauthorizedTls) {
@@ -334,33 +333,33 @@ FtpConnection.prototype._secureChannel = function(type) {
 };
 
 // Change working directory to parent directory
-FtpConnection.prototype._command_CDUP = function(release) {
+FtpConnection.prototype._command_CDUP = function(done) {
   var pathServer = path.dirname(this.cwd);
   var pathEscaped = pathEscape(pathServer);
   this.cwd = pathServer;
-  this.respond('250 Directory changed to "' + pathEscaped + '"', release);
+  this.respond('250 Directory changed to "' + pathEscaped + '"', done);
 };
 
 // Change working directory
-FtpConnection.prototype._command_CWD = function(release, pathRequest) {
+FtpConnection.prototype._command_CWD = function(done, pathRequest) {
   var pathServer = withCwd(this.cwd, pathRequest);
   var pathFs = path.join(this.root, pathServer);
   var pathEscaped = pathEscape(pathServer);
   this.fs.stat(pathFs, function(err, stats) {
     if (err) {
       this._logIf(LOG.ERROR, 'CWD ' + pathRequest + ': ' + err);
-      this.respond('550 Directory not found.', release);
+      this.respond('550 Directory not found.', done);
     } else if (!stats.isDirectory()) {
       this._logIf(LOG.WARN, 'Attempt to CWD to non-directory');
-      this.respond('550 Not a directory', release);
+      this.respond('550 Not a directory', done);
     } else {
       this.cwd = pathServer;
-      this.respond('250 CWD successful. "' + pathEscaped + '" is current directory', release);
+      this.respond('250 CWD successful. "' + pathEscaped + '" is current directory', done);
     }
   }.bind(this));
 };
 
-FtpConnection.prototype._command_DELE = function(release, commandArg) {
+FtpConnection.prototype._command_DELE = function(done, commandArg) {
   var self = this;
 
   var filename = withCwd(self.cwd, commandArg);
@@ -368,14 +367,14 @@ FtpConnection.prototype._command_DELE = function(release, commandArg) {
     if (err) {
       self._logIf(LOG.ERROR, 'Error deleting file: ' + filename + ', ' + err);
       // write error to socket
-      self.respond('550 Permission denied', release);
+      self.respond('550 Permission denied', done);
     } else {
-      self.respond('250 File deleted', release);
+      self.respond('250 File deleted', done);
     }
   });
 };
 
-FtpConnection.prototype._command_FEAT = function(release) {
+FtpConnection.prototype._command_FEAT = function(done) {
   // Get the feature list implemented by the server. (RFC 2389)
   this.respond(
     '211-Features\r\n' +
@@ -389,50 +388,50 @@ FtpConnection.prototype._command_FEAT = function(release) {
                   ' PROT\r\n'
           ) +
           '211 end',
-    release
+    done
   );
 };
 
-FtpConnection.prototype._command_OPTS = function(release, commandArg) {
+FtpConnection.prototype._command_OPTS = function(done, commandArg) {
   // http://tools.ietf.org/html/rfc2389#section-4
   if (commandArg.toUpperCase() === 'UTF8 ON') {
-    this.respond('200 OK', release);
+    this.respond('200 OK', done);
   } else {
-    this.respond('451 Not supported', release);
+    this.respond('451 Not supported', done);
   }
 };
 
 // Print the file modification time
-FtpConnection.prototype._command_MDTM = function(release, file) {
+FtpConnection.prototype._command_MDTM = function(done, file) {
   var self = this;
   file = withCwd(this.cwd, file);
   file = path.join(this.root, file);
   this.fs.stat(file, function(err, stats) {
     if (err) {
-      self.respond('550 File unavailable', release);
+      self.respond('550 File unavailable', done);
     } else {
-      self.respond('213 ' + dateformat(stats.mtime, 'yyyymmddhhMMss'), release);
+      self.respond('213 ' + dateformat(stats.mtime, 'yyyymmddhhMMss'), done);
     }
   });
 };
 
-FtpConnection.prototype._command_LIST = function(release, commandArg) {
-  this._LIST(release, commandArg, true, 'LIST');
+FtpConnection.prototype._command_LIST = function(done, commandArg) {
+  this._LIST(done, commandArg, true, 'LIST');
 };
 
-FtpConnection.prototype._command_NLST = function(release, commandArg) {
-  this._LIST(release, commandArg, false, 'NLST');
+FtpConnection.prototype._command_NLST = function(done, commandArg) {
+  this._LIST(done, commandArg, false, 'NLST');
 };
 
-FtpConnection.prototype._command_STAT = function(release, commandArg) {
+FtpConnection.prototype._command_STAT = function(done, commandArg) {
   if (commandArg) {
-    this._LIST(release, commandArg, true, 'STAT');
+    this._LIST(done, commandArg, true, 'STAT');
   } else {
-    this.respond('211 FTP Server Status OK', release);
+    this.respond('211 FTP Server Status OK', done);
   }
 };
 
-FtpConnection.prototype._LIST = function(release, commandArg, detailed, cmd) {
+FtpConnection.prototype._LIST = function(done, commandArg, detailed, cmd) {
   /*
    Normally the server responds with a mark using code 150. It then stops accepting new connections, attempts to send the contents of the directory over the data connection, and closes the data connection. Finally it
 
@@ -455,7 +454,7 @@ FtpConnection.prototype._LIST = function(release, commandArg, detailed, cmd) {
   glob.glob(path.join(self.root, dir), self.fs, function(err, files) {
     if (err) {
       self._logIf(LOG.ERROR, 'Error sending file list, reading directory: ' + err);
-      self.respond('550 Not a directory', release);
+      self.respond('550 Not a directory', done);
       return;
     }
 
@@ -469,7 +468,7 @@ FtpConnection.prototype._LIST = function(release, commandArg, detailed, cmd) {
 
     self._logIf(LOG.INFO, 'Directory has ' + files.length + ' files');
     if (files.length === 0) {
-      return self._listFiles(release, [], detailed, cmd);
+      return self._listFiles(done, [], detailed, cmd);
     }
 
     var fileInfos; // To contain list of files with info for each.
@@ -547,12 +546,12 @@ FtpConnection.prototype._LIST = function(release, commandArg, detailed, cmd) {
         });
       }
 
-      self._listFiles(release, fileInfos, detailed, cmd);
+      self._listFiles(done, fileInfos, detailed, cmd);
     }
   }, self.server.options.noWildcards);
 };
 
-FtpConnection.prototype._listFiles = function(release, fileInfos, detailed, cmd) {
+FtpConnection.prototype._listFiles = function(done, fileInfos, detailed, cmd) {
   var self = this;
 
   var m = '150 Here comes the directory listing';
@@ -565,7 +564,7 @@ FtpConnection.prototype._listFiles = function(release, fileInfos, detailed, cmd)
   };
 
   self.respond(BEGIN_MSGS[cmd], function() {
-    release();
+    done();
     if (cmd === 'STAT') {
       writeFileList(self.socket);
     } else {
@@ -621,34 +620,34 @@ FtpConnection.prototype._listFiles = function(release, fileInfos, detailed, cmd)
 };
 
 // Create a directory
-FtpConnection.prototype._command_MKD = function(release, pathRequest) {
+FtpConnection.prototype._command_MKD = function(done, pathRequest) {
   var pathServer = withCwd(this.cwd, pathRequest);
   var pathEscaped = pathEscape(pathServer);
   var pathFs = path.join(this.root, pathServer);
   this.fs.mkdir(pathFs, 0755, function(err) {
     if (err) {
       this._logIf(LOG.ERROR, 'MKD ' + pathRequest + ': ' + err);
-      this.respond('550 "' + pathEscaped + '" directory NOT created', release);
+      this.respond('550 "' + pathEscaped + '" directory NOT created', done);
     } else {
-      this.respond('257 "' + pathEscaped + '" directory created', release);
+      this.respond('257 "' + pathEscaped + '" directory created', done);
     }
   }.bind(this));
 };
 
 // Perform a no-op (used to keep-alive connection)
-FtpConnection.prototype._command_NOOP = function(release) {
-  this.respond('200 OK', release);
+FtpConnection.prototype._command_NOOP = function(done) {
+  this.respond('200 OK', done);
 };
 
-FtpConnection.prototype._command_PORT = function(release, x, y) {
-  this._PORT(release, x, y);
+FtpConnection.prototype._command_PORT = function(done, x, y) {
+  this._PORT(done, x, y);
 };
 
-FtpConnection.prototype._command_EPRT = function(release, x, y) {
-  this._PORT(release, x, y);
+FtpConnection.prototype._command_EPRT = function(done, x, y) {
+  this._PORT(done, x, y);
 };
 
-FtpConnection.prototype._PORT = function(release, commandArg, command) {
+FtpConnection.prototype._PORT = function(done, commandArg, command) {
   var self = this;
   var m;
   var host;
@@ -660,7 +659,7 @@ FtpConnection.prototype._PORT = function(release, commandArg, command) {
   if (command === 'PORT') {
     m = commandArg.match(/^([0-9]{1,3}),([0-9]{1,3}),([0-9]{1,3}),([0-9]{1,3}),([0-9]{1,3}),([0-9]{1,3})$/);
     if (!m) {
-      return self.respond('501 Bad argument to PORT', release);
+      return self.respond('501 Bad argument to PORT', done);
     }
 
     host = m[1] + '.' + m[2] + '.' + m[3] + '.' + m[4];
@@ -673,12 +672,12 @@ FtpConnection.prototype._PORT = function(release, commandArg, command) {
     if (commandArg.length >= 3 && commandArg.charAt(0) === '|' &&
         commandArg.charAt(2) === '|' && commandArg.charAt(1) === '2') {
       // Only IPv4 is supported.
-      return self.respond('522 Server cannot handle IPv6 EPRT commands, use (1)', release);
+      return self.respond('522 Server cannot handle IPv6 EPRT commands, use (1)', done);
     }
 
     m = commandArg.match(/^\|1\|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})\|([0-9]{1,5})/);
     if (!m) {
-      return self.respond('501 Bad Argument to EPRT', release);
+      return self.respond('501 Bad Argument to EPRT', done);
     }
 
     var r = parseInt(m[2], 10);
@@ -692,31 +691,31 @@ FtpConnection.prototype._PORT = function(release, commandArg, command) {
   }
 
   if (port > 65535 || port < 1024) {
-    return self.respond('501 Bad argument to ' + command + ' (invalid port number)', release);
+    return self.respond('501 Bad argument to ' + command + ' (invalid port number)', done);
   }
 
   self.dataConfigured = true;
   self.dataHost = host;
   self.dataPort = port;
   self._logIf(LOG.DEBUG, 'self.dataHost, self.dataPort set to ' + self.dataHost + ':' + self.dataPort);
-  self.respond('200 OK', release);
+  self.respond('200 OK', done);
 };
 
-FtpConnection.prototype._command_PASV = function(release, x, y) {
-  this._PASV(release, x, y);
+FtpConnection.prototype._command_PASV = function(done, x, y) {
+  this._PASV(done, x, y);
 };
 
-FtpConnection.prototype._command_EPSV = function(release, x, y) {
-  this._PASV(release, x, y);
+FtpConnection.prototype._command_EPSV = function(done, x, y) {
+  this._PASV(done, x, y);
 };
 
-FtpConnection.prototype._PASV = function(release, commandArg, command) {
+FtpConnection.prototype._PASV = function(done, commandArg, command) {
   var self = this;
 
   self.dataConfigured = false;
 
   if (command === 'EPSV' && commandArg && commandArg !== '1') {
-    return self.respond('202 Not supported', release);
+    return self.respond('202 Not supported', done);
   }
 
   // not sure whether the spec limits to 1 data connection at a time ...
@@ -725,10 +724,10 @@ FtpConnection.prototype._PASV = function(release, commandArg, command) {
     self.dataSocket = null;
   }
 
-  self._setupPASV(release, commandArg, command);
+  self._setupPASV(done, commandArg, command);
 };
 
-FtpConnection.prototype._writePASVReady = function(release, command) {
+FtpConnection.prototype._writePASVReady = function(done, command) {
   var self = this;
 
   self.dataConfigured = true;
@@ -740,9 +739,9 @@ FtpConnection.prototype._writePASVReady = function(release, command) {
   if (command === 'PASV') {
     var i1 = (port / 256) | 0;
     var i2 = port % 256;
-    self.respond('227 Entering Passive Mode (' + host.split('.').join(',') + ',' + i1 + ',' + i2 + ')', release);
+    self.respond('227 Entering Passive Mode (' + host.split('.').join(',') + ',' + i1 + ',' + i2 + ')', done);
   } else { // EPASV
-    self.respond('229 Entering Extended Passive Mode (|||' + port + '|)', release);
+    self.respond('229 Entering Extended Passive Mode (|||' + port + '|)', done);
   }
 };
 
@@ -750,11 +749,11 @@ FtpConnection.prototype._writePASVReady = function(release, command) {
 //     (i)   It works
 //     (ii)  We get an error that's not just EADDRINUSE
 //     (iii) We run out of ports to try.
-FtpConnection.prototype._setupPASV = function(release, commandArg, command) {
+FtpConnection.prototype._setupPASV = function(done, commandArg, command) {
   var self = this;
 
   if (self.pasv) {
-    self._writePASVReady(release, command);
+    self._writePASVReady(done, command);
     return;
   }
 
@@ -771,7 +770,7 @@ FtpConnection.prototype._setupPASV = function(release, commandArg, command) {
       }
 
       self._logIf(LOG.WARN, 'Passive Error with passive data listener: ' + util.inspect(e));
-      self.respond('421 Server was unable to open passive connection listener', release);
+      self.respond('421 Server was unable to open passive connection listener', done);
       self.dataConfigured = false;
       self.dataSocket = null;
       self.pasv = null;
@@ -781,7 +780,7 @@ FtpConnection.prototype._setupPASV = function(release, commandArg, command) {
     .on('listening', function() {
       self._logIf(LOG.DEBUG, 'Passive data connection listening on port ' + this.address().port);
       self.pasv = this;
-      self._writePASVReady(release, command);
+      self._writePASVReady(done, command);
     })
 
     .on('close', function() {
@@ -792,7 +791,7 @@ FtpConnection.prototype._setupPASV = function(release, commandArg, command) {
     .listen(firstPort || lastPort || 0);
 };
 
-FtpConnection.prototype._command_PBSZ = function(release, commandArg) {
+FtpConnection.prototype._command_PBSZ = function(done, commandArg) {
   if (this.secure) {
     this.pbszReceived = true;
   }
@@ -806,37 +805,37 @@ FtpConnection.prototype._command_PBSZ = function(release, commandArg) {
         // Doubt that this will do any good if the client was already confused
         // enough to send a non-zero value, but ok...
           '200 OK',
-    release
+    done
   );
 };
 
-FtpConnection.prototype._command_PROT = function(release, commandArg) {
+FtpConnection.prototype._command_PROT = function(done, commandArg) {
   this.respond(
     !this.server.options.tlsOptions ? '202 Not supported' :
       !this.pbszReceived ? '503 No PBSZ command received' :
         (commandArg === 'S' || commandArg === 'E' || commandArg === 'C') ? '536 Not supported' :
           commandArg !== 'P' ? '504 Not recognized' /* Don't even recognize this one... */ :
             '200 OK',
-    release
+    done
   );
 };
 
 // Print the current working directory.
-FtpConnection.prototype._command_PWD = function(release, commandArg) {
+FtpConnection.prototype._command_PWD = function(done, commandArg) {
   this.respond(
     commandArg === ''
       ? '257 "' + pathEscape(this.cwd) + '" is current directory'
       : '501 Syntax error in parameters or arguments.',
-    release
+    done
   );
 };
 
-FtpConnection.prototype._command_QUIT = function(release) {
+FtpConnection.prototype._command_QUIT = function(done) {
   var self = this;
 
   self.hasQuit = true;
   self.respond('221 Goodbye', function(err) {
-    release();
+    done();
     if (err) {
       self._logIf(LOG.ERROR, "Error writing 'Goodbye' message following QUIT");
     }
@@ -845,17 +844,17 @@ FtpConnection.prototype._command_QUIT = function(release) {
   });
 };
 
-FtpConnection.prototype._command_RETR = function(release, commandArg) {
+FtpConnection.prototype._command_RETR = function(done, commandArg) {
   var filename = path.join(this.root, withCwd(this.cwd, commandArg));
 
   if (this.server.options.useReadFile) {
-    this._RETR_usingReadFile(release, commandArg, filename);
+    this._RETR_usingReadFile(done, commandArg, filename);
   } else {
-    this._RETR_usingCreateReadStream(release, commandArg, filename);
+    this._RETR_usingCreateReadStream(done, commandArg, filename);
   }
 };
 
-FtpConnection.prototype._RETR_usingCreateReadStream = function(release, commandArg, filename) {
+FtpConnection.prototype._RETR_usingCreateReadStream = function(done, commandArg, filename) {
   var self = this;
   var startTime = new Date();
 
@@ -882,14 +881,14 @@ FtpConnection.prototype._RETR_usingCreateReadStream = function(release, commandA
         error: err,
       });
       if (err.code === 'ENOENT') {
-        self.respond('550 Not Found', release);
+        self.respond('550 Not Found', done);
       } else { // Who knows what's going on here...
-        self.respond('550 Not Accessible', release);
+        self.respond('550 Not Accessible', done);
         self._logIf(LOG.ERROR, "Error at read of '" + filename + "' other than ENOENT " + err);
       }
     } else {
       afterOk(function() {
-        release();
+        done();
         self._whenDataReady(function(socket) {
           var readLength = 0;
           var now = new Date();
@@ -938,7 +937,7 @@ FtpConnection.prototype._RETR_usingCreateReadStream = function(release, commandA
   });
 };
 
-FtpConnection.prototype._RETR_usingReadFile = function(release, commandArg, filename) {
+FtpConnection.prototype._RETR_usingReadFile = function(done, commandArg, filename) {
   var self = this;
   var startTime = new Date();
 
@@ -967,14 +966,14 @@ FtpConnection.prototype._RETR_usingReadFile = function(release, commandArg, file
         error: err,
       });
       if (err.code === 'ENOENT') {
-        self.respond('550 Not Found', release);
+        self.respond('550 Not Found', done);
       } else { // Who knows what's going on here...
-        self.respond('550 Not Accessible', release);
+        self.respond('550 Not Accessible', done);
         self._logIf(LOG.ERROR, "Error at read of '" + filename + "' other than ENOENT " + err);
       }
     } else {
       afterOk(function() {
-        release();
+        done();
         self._whenDataReady(function(socket) {
           self.emit('file:retr:contents', {filename: filename, data: contents});
           socket.write(contents);
@@ -1002,78 +1001,78 @@ FtpConnection.prototype._RETR_usingReadFile = function(release, commandArg, file
 };
 
 // Remove a directory
-FtpConnection.prototype._command_RMD = function(release, pathRequest) {
+FtpConnection.prototype._command_RMD = function(done, pathRequest) {
   var pathServer = withCwd(this.cwd, pathRequest);
   var pathFs = path.join(this.root, pathServer);
   this.fs.rmdir(pathFs, function(err) {
     if (err) {
       this._logIf(LOG.ERROR, 'RMD ' + pathRequest + ': ' + err);
-      this.respond('550 Delete operation failed', release);
+      this.respond('550 Delete operation failed', done);
     } else {
-      this.respond('250 "' + pathServer + '" directory removed', release);
+      this.respond('250 "' + pathServer + '" directory removed', done);
     }
   }.bind(this));
 };
 
-FtpConnection.prototype._command_RNFR = function(release, commandArg) {
+FtpConnection.prototype._command_RNFR = function(done, commandArg) {
   var self = this;
   self.filefrom = withCwd(self.cwd, commandArg);
   self._logIf(LOG.DEBUG, 'Rename from ' + self.filefrom);
-  self.respond('350 Ready for destination name', release);
+  self.respond('350 Ready for destination name', done);
 };
 
-FtpConnection.prototype._command_RNTO = function(release, commandArg) {
+FtpConnection.prototype._command_RNTO = function(done, commandArg) {
   var self = this;
   var fileto = withCwd(self.cwd, commandArg);
   self.fs.rename(path.join(self.root, self.filefrom), path.join(self.root, fileto), function(err) {
     if (err) {
       self._logIf(LOG.ERROR, 'Error renaming file from ' + self.filefrom + ' to ' + fileto);
-      self.respond('550 Rename failed' + (err.code === 'ENOENT' ? '; file does not exist' : '', release));
+      self.respond('550 Rename failed' + (err.code === 'ENOENT' ? '; file does not exist' : '', done));
     } else {
-      self.respond('250 File renamed successfully', release);
+      self.respond('250 File renamed successfully', done);
     }
   });
 };
 
-FtpConnection.prototype._command_SIZE = function(release, commandArg) {
+FtpConnection.prototype._command_SIZE = function(done, commandArg) {
   var self = this;
 
   var filename = withCwd(self.cwd, commandArg);
   self.fs.stat(path.join(self.root, filename), function(err, s) {
     if (err) {
       self._logIf(LOG.ERROR, "Error getting size of file '" + filename + "' ");
-      self.respond('450 Failed to get size of file', release);
+      self.respond('450 Failed to get size of file', done);
       return;
     }
-    self.respond('213 ' + s.size + '', release);
+    self.respond('213 ' + s.size + '', done);
   });
 };
 
-FtpConnection.prototype._command_TYPE = function(release, commandArg) {
+FtpConnection.prototype._command_TYPE = function(done, commandArg) {
   this.respond(
     commandArg === 'I' || commandArg === 'A'
       ? '200 OK'
       : '202 Not supported',
-    release
+    done
   );
 };
 
-FtpConnection.prototype._command_SYST = function(release) {
-  this.respond('215 UNIX Type: I', release);
+FtpConnection.prototype._command_SYST = function(done) {
+  this.respond('215 UNIX Type: I', done);
 };
 
-FtpConnection.prototype._command_STOR = function(release, commandArg) {
+FtpConnection.prototype._command_STOR = function(done, commandArg) {
   var filename = withCwd(this.cwd, commandArg);
 
   if (this.server.options.useWriteFile) {
-    this._STOR_usingWriteFile(release, filename, 'w');
+    this._STOR_usingWriteFile(done, filename, 'w');
   } else {
-    this._STOR_usingCreateWriteStream(release, filename, null, 'w');
+    this._STOR_usingCreateWriteStream(done, filename, null, 'w');
   }
 };
 
 // 'initialBuffers' argument is set when this is called from _STOR_usingWriteFile.
-FtpConnection.prototype._STOR_usingCreateWriteStream = function(release, filename, initialBuffers, flag) {
+FtpConnection.prototype._STOR_usingCreateWriteStream = function(done, filename, initialBuffers, flag) {
   var self = this;
 
   var wStreamFlags = {flags: flag || 'w', mode: 0644};
@@ -1107,7 +1106,7 @@ FtpConnection.prototype._STOR_usingCreateWriteStream = function(release, filenam
       time: startTime,
     });
 
-    self.respond('150 Ok to send data', release);
+    self.respond('150 Ok to send data', done);
   });
 
   storeStream.on('error', function() {
@@ -1153,7 +1152,7 @@ FtpConnection.prototype._STOR_usingCreateWriteStream = function(release, filenam
 
 };
 
-FtpConnection.prototype._STOR_usingWriteFile = function(release, filename, flag) {
+FtpConnection.prototype._STOR_usingWriteFile = function(done, filename, flag) {
   var self = this;
 
   var erroredOut = false;
@@ -1168,7 +1167,7 @@ FtpConnection.prototype._STOR_usingWriteFile = function(release, filename, flag)
   });
 
   self.respond('150 Ok to send data', function() {
-    release();
+    done();
     self._whenDataReady(function(socket) {
       socket.on('data', dataHandler);
       socket.once('close', closeHandler);
@@ -1196,7 +1195,7 @@ FtpConnection.prototype._STOR_usingWriteFile = function(release, filename, flag)
       // Otherwise, we call _STOR_usingWriteStream, and tell it to prepend the stuff
       // that we've buffered so far to the file.
       self._logIf(LOG.WARN, 'uploadMaxSlurpSize exceeded; falling back to createWriteStream');
-      self._STOR_usingCreateWriteStream(release, filename, [slurpBuf.slice(0, totalBytes), buf]);
+      self._STOR_usingCreateWriteStream(done, filename, [slurpBuf.slice(0, totalBytes), buf]);
       self.dataSocket.removeListener('data', dataHandler);
       self.dataSocket.removeListener('error', errorHandler);
       self.dataSocket.removeListener('close', closeHandler);
@@ -1258,18 +1257,18 @@ FtpConnection.prototype._STOR_usingWriteFile = function(release, filename, flag)
   }
 };
 
-FtpConnection.prototype._command_APPE = function(release, commandArg) {
+FtpConnection.prototype._command_APPE = function(done, commandArg) {
   var filename = withCwd(this.cwd, commandArg);
 
   if (this.server.options.useWriteFile) {
-    this._STOR_usingWriteFile(release, filename, 'a');
+    this._STOR_usingWriteFile(done, filename, 'a');
   } else {
-    this._STOR_usingCreateWriteStream(release, filename, null, 'a');
+    this._STOR_usingCreateWriteStream(done, filename, null, 'a');
   }
 };
 
 // Specify a username for login
-FtpConnection.prototype._command_USER = function(release, username) {
+FtpConnection.prototype._command_USER = function(done, username) {
   var self = this;
 
   if (self.server.options.tlsOnly && !self.secure) {
@@ -1277,39 +1276,39 @@ FtpConnection.prototype._command_USER = function(release, username) {
       '530 This server does not permit login over ' +
       'a non-secure connection; ' +
       'connect using FTP-SSL with explicit AUTH TLS',
-      release);
+      done);
   } else {
     self.emit('command:user', username,
       function success() {
-        self.respond('331 User name okay, need password.', release);
+        self.respond('331 User name okay, need password.', done);
       },
       function failure() {
-        self.respond('530 Not logged in.', release);
+        self.respond('530 Not logged in.', done);
       }
     );
   }
 };
 
 // Specify a password for login
-FtpConnection.prototype._command_PASS = function(release, password) {
+FtpConnection.prototype._command_PASS = function(done, password) {
   var self = this;
 
   if (self.previousCommand !== 'USER') {
-    self.respond('503 Bad sequence of commands.', release);
+    self.respond('503 Bad sequence of commands.', done);
   } else {
     self.emit('command:pass', password,
       function success(username, userFsModule) {
         function panic(error, method) {
           self._logIf(LOG.ERROR, method + ' signaled error ' + util.inspect(error));
           self.respond('421 Service not available, closing control connection.', function() {
-            release();
+            done();
             self._closeSocket(self.socket, true);
           });
         }
         function setCwd(cwd) {
           function setRoot(root) {
             self.root = root;
-            self.respond('230 User logged in, proceed.', release);
+            self.respond('230 User logged in, proceed.', done);
           }
 
           self.cwd = cwd;
@@ -1340,7 +1339,7 @@ FtpConnection.prototype._command_PASS = function(release, password) {
         }
       },
       function failure() {
-        self.respond('530 Not logged in.', release);
+        self.respond('530 Not logged in.', done);
         self.username = null;
       }
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -157,6 +157,11 @@
       "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
       "dev": true
     },
+    "async-lock": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.3.0.tgz",
+      "integrity": "sha512-8A7SkiisnEgME2zEedtDYPxUPzdv3x//E7n5IFktPAtMYSEAV7eNJF0rMwrVyUFj6d/8rgajLantbjcNRQYXIg=="
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1042,11 +1047,6 @@
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
       }
-    },
-    "lock": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/lock/-/lock-1.1.0.tgz",
-      "integrity": "sha1-UxV0mdFlOxNspmRRBx/KYVcD+lU="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -111,8 +111,8 @@
     "url": "https://github.com/sstur/nodeftpd/issues"
   },
   "dependencies": {
+    "async-lock": "^1.3.0",
     "dateformat": "1.0.7-1.2.3",
-    "lock": "^1.1.0",
     "stat-mode": "^0.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
If a command handler throws an error, release the lock, it may not have had a chance to do so.

Swapped libraries, as the former did not allow multiple calls to release.