### PR TITLE
Use local lock instance.

### DIFF
--- a/lib/FtpConnection.js
+++ b/lib/FtpConnection.js
@@ -19,7 +19,6 @@ var stripOptions = require('./helpers/stripOptions');
 var leftPad = require('./helpers/leftPad');
 
 var EventEmitter = events.EventEmitter;
-var lock = new AsyncLock();
 
 // Use LOG for brevity.
 var LOG = Constants.LOG_LEVELS;
@@ -36,6 +35,7 @@ function FtpConnection(properties) {
     self[key] = properties[key];
   });
 
+  self.lock = new AsyncLock();
   self.socket.setTimeout(0);
   self.socket.setNoDelay();
 
@@ -235,7 +235,7 @@ FtpConnection.prototype._onData = function(data) {
     return;
   }
 
-  lock.acquire('command', function(done) {
+  self.lock.acquire('command', function(done) {
     var m = '_command_' + command;
     if (!self[m]) {
       return self.respond('502 Command not implemented.', done);


### PR DESCRIPTION
Don't share the lock instance between connections.